### PR TITLE
WIP Use the first domain on the list as the common name

### DIFF
--- a/src/helpers/CommonHelper.php
+++ b/src/helpers/CommonHelper.php
@@ -124,20 +124,7 @@ class CommonHelper
      */
     public static function getCommonNameForCSR($domainList)
     {
-        $domainLevel = [];
-
-        foreach ($domainList as $domain)
-        {
-            $domainLevel[count(explode('.', $domain))][] = $domain;
-        }
-
-        ksort($domainLevel);
-
-        $shortestDomainList = reset($domainLevel);
-
-        sort($shortestDomainList);
-
-        return $shortestDomainList[0];
+        return $domainList[0];
     }
 
     /**


### PR DESCRIPTION
At the moment, the common name for the certificate is selected based on domains with the least number of `.` so at the moment its not customisable. This proposed minimal change give the caller at least some control of what domain to use as the common name.  

Even though the use of common name is deprecated according to [RFC2818](https://datatracker.ietf.org/doc/html/rfc2818#section-3), some customers (we have one) would like a specific common name in their SSL certificate for presentation. eg the same certificate is used by several groups within a larger organisation.
